### PR TITLE
update-shared-ci: fix listing of modified files

### DIFF
--- a/.github/workflows/update-shared-ci.yaml
+++ b/.github/workflows/update-shared-ci.yaml
@@ -34,7 +34,7 @@ jobs:
           EOF
 
           mapfile -t merge_conflicts < <(
-            git ls-files --modified | xargs grep --files-with-matches '^<<<<<<< ours'
+            git diff --diff-filter=M --name-only | xargs grep --files-with-matches '^<<<<<<< ours'
           )
           mapfile -t rejected_patches < <(
             git ls-files --others | grep '\.rej$'

--- a/{{cookiecutter.repo_root}}/.github/workflows/update-shared-ci.yaml
+++ b/{{cookiecutter.repo_root}}/.github/workflows/update-shared-ci.yaml
@@ -34,7 +34,7 @@ jobs:
           EOF
 
           mapfile -t merge_conflicts < <(
-            git ls-files --modified | xargs grep --files-with-matches '^<<<<<<< ours'
+            git diff --diff-filter=M --name-only | xargs grep --files-with-matches '^<<<<<<< ours'
           )
           mapfile -t rejected_patches < <(
             git ls-files --others | grep '\.rej$'


### PR DESCRIPTION
Turns out 'git ls-files --modified' also lists deleted files. Switch to 'git diff --diff-filter=M', which only lists modified files as expected.