### PR TITLE
Prepare to onboard this repo to Renovate

### DIFF
--- a/.github/workflows/update-shared-ci.yaml
+++ b/.github/workflows/update-shared-ci.yaml
@@ -58,8 +58,30 @@ jobs:
             echo draft=false >> "$GITHUB_OUTPUT"
           fi
 
-          if [[ ! -e renovate.json ]]; then
-            echo "renovate.json doesn't exist, skipping update" >&2
+          renovate_config_exists() {
+            # https://docs.renovatebot.com/configuration-options/
+            local renovate_config_paths=(
+              renovate.json
+              renovate.json5
+              .github/renovate.json
+              .github/renovate.json5
+              .gitlab/renovate.json
+              .gitlab/renovate.json5
+              .renovaterc
+              .renovaterc.json
+              .renovaterc.json5
+            )
+
+            for file in "${renovate_config_paths[@]}"; do
+              if [[ -e "$file" ]]; then
+                return 0
+              fi
+            done
+
+            return 1
+          }
+          if ! renovate_config_exists; then
+            echo "Renovate config file not found, skipping update" >&2
             exit
           fi
 

--- a/.github/workflows/update-shared-ci.yaml
+++ b/.github/workflows/update-shared-ci.yaml
@@ -58,6 +58,29 @@ jobs:
             echo draft=false >> "$GITHUB_OUTPUT"
           fi
 
+          if [[ ! -e renovate.json ]]; then
+            echo "renovate.json doesn't exist, skipping update" >&2
+            exit
+          fi
+
+          renovate_update_script=hack/renovate-ignore-shared-ci.sh
+
+          for conflict in "${merge_conflicts[@]}" "${rejected_patches[@]}"; do
+            if [[ "$conflict" == "$renovate_update_script" ]]; then
+              cat << EOF >> /tmp/body.md
+
+          > [!WARNING]
+          >
+          > \`$renovate_update_script\` has a merge conflict, the workflow couldn't run it.
+          > After resolving the conflict, please run the script manually.
+          EOF
+              echo "cannot run $renovate_update_script due to merge conflict, skipping" >&2
+              exit
+            fi
+          done
+
+          bash "$renovate_update_script"
+
       - uses: actions/create-github-app-token@v2.0.6
         id: app-token
         with:

--- a/README.md
+++ b/README.md
@@ -41,10 +41,17 @@ Process:
    git diff --diff-filter=D --name-only -- .github/ hack/ | xargs git checkout --
    ```
 
-4. Commit the files brought in from the template repo
+4. If you use [Renovate], create/update your renovate.json using the
+   [`hack/renovate-ignore-shared-ci.sh`](hack/renovate-ignore-shared-ci.sh) script:
 
    ```bash
-   git add .cruft.json .github/ hack/ SHARED-CI.md
+   hack/renovate-ignore-shared-ci.sh
+   ```
+
+5. Commit the files brought in during the onboarding
+
+   ```bash
+   git add .cruft.json renovate.json .github/ hack/ SHARED-CI.md
    git commit
    ```
 
@@ -124,3 +131,4 @@ to keep it up to date.
 [template repo]: https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository
 [cookiecutter]: https://cookiecutter.readthedocs.io/en/stable/
 [uv]: https://docs.astral.sh/uv/
+[Renovate]: https://docs.renovatebot.com/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Process:
    ```
 
 4. If you use [Renovate], create/update your renovate.json using the
-   [`hack/renovate-ignore-shared-ci.sh`](hack/renovate-ignore-shared-ci.sh) script:
+   [`hack/renovate-ignore-shared-ci.sh`](hack/renovate-ignore-shared-ci.sh) script
+   (see [why](./SHARED-CI.md#conflicts-with-renovate)):
 
    ```bash
    hack/renovate-ignore-shared-ci.sh

--- a/SHARED-CI.md
+++ b/SHARED-CI.md
@@ -188,17 +188,6 @@ run the script to automatically update `renovate.json`.
 This ensures your Shared CI workflows follow the GitHub Actions versions defined
 in the upstream reposistory and avoids unnecessary merge conflicts.
 
-[task-repo-shared-ci]: https://github.com/konflux-ci/task-repo-shared-ci
-[onboarding process]: https://github.com/konflux-ci/task-repo-shared-ci?tab=readme-ov-file#-onboarding
-[cruft]: https://cruft.github.io/cruft
-[uv]: https://docs.astral.sh/uv/
-[recipe.yaml]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts#configuration-in-recipeyaml
-[trusted-artifacts generator]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts
-[GITHUB_TOKEN]: https://docs.github.com/en/actions/concepts/security/github_token
-[tekton-catalog-structure]: https://github.com/tektoncd/catalog?tab=readme-ov-file#catalog-structure
-[Renovate]: https://docs.renovatebot.com/
-[renovate-ignorepaths]: https://docs.renovatebot.com/configuration-options/#ignorepaths
-
 ### Task Integration Tests
 
 - workflow: [`.github/workflows/run-task-tests.yaml`](.github/workflows/run-task-tests.yaml)
@@ -288,3 +277,15 @@ This check **disallows using `$(params.*)` variable substitution directly within
 Using `$(params.*)` directly in a script creates a security flaw. Tekton performs a raw text replacement of the parameter placeholder before the script is executed. This means if a parameter's value contains malicious shell commands, they will be run, leading to **arbitrary code execution**.
 
 For more details and guidance on fixing the issue, see the [Tekton recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md#dont-use-interpolation-in-scripts-or-string-arguments)
+
+
+[task-repo-shared-ci]: https://github.com/konflux-ci/task-repo-shared-ci
+[onboarding process]: https://github.com/konflux-ci/task-repo-shared-ci?tab=readme-ov-file#-onboarding
+[cruft]: https://cruft.github.io/cruft
+[uv]: https://docs.astral.sh/uv/
+[recipe.yaml]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts#configuration-in-recipeyaml
+[trusted-artifacts generator]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts
+[GITHUB_TOKEN]: https://docs.github.com/en/actions/concepts/security/github_token
+[tekton-catalog-structure]: https://github.com/tektoncd/catalog?tab=readme-ov-file#catalog-structure
+[Renovate]: https://docs.renovatebot.com/
+[renovate-ignorepaths]: https://docs.renovatebot.com/configuration-options/#ignorepaths

--- a/SHARED-CI.md
+++ b/SHARED-CI.md
@@ -122,6 +122,10 @@ You can also trigger it manually from the Actions tab of your repo.
 > can encounter merge conflicts. When that happens, the workflow will send the
 > PR anyway but with the merge conflicts included. The PR will be in draft state
 > and will include a caution note (like this one, but red) with instructions.
+>
+> If your repository uses Renovate for automated dependency updates, that may increase
+> the chance of merge conflicts. See [Conflicts with Renovate](#conflicts-with-renovate)
+> for the solution.
 
 #### Required secrets
 
@@ -169,13 +173,31 @@ to avoid those restrictions.
    - `SHARED_CI_UPDATER_APP_ID`: the App ID number
    - `SHARED_CI_UPDATER_PRIVATE_KEY`: plaintext content of the private key
 
+#### Conflicts with Renovate
+
+If your repository uses [Renovate], you could frequently get merge conflicts
+during the Shared CI updates, because your repository gets GitHub Actions updates
+at a different rate than the upstream [task-repo-shared-ci] repository.
+
+To avoid that, your repo gets the [`hack/renovate-ignore-shared-ci.sh`](hack/renovate-ignore-shared-ci.sh)
+script. Run this script during the [onboarding process] to add all the Shared CI
+workflows to the [`ignorePaths`][renovate-ignorepaths] in your `renovate.json`.
+Afterwards, any time the updater workflow brings in a new workflow file, it will
+run the script to automatically update `renovate.json`.
+
+This ensures your Shared CI workflows follow the GitHub Actions versions defined
+in the upstream reposistory and avoids unnecessary merge conflicts.
+
 [task-repo-shared-ci]: https://github.com/konflux-ci/task-repo-shared-ci
+[onboarding process]: https://github.com/konflux-ci/task-repo-shared-ci?tab=readme-ov-file#-onboarding
 [cruft]: https://cruft.github.io/cruft
 [uv]: https://docs.astral.sh/uv/
 [recipe.yaml]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts#configuration-in-recipeyaml
 [trusted-artifacts generator]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts
 [GITHUB_TOKEN]: https://docs.github.com/en/actions/concepts/security/github_token
 [tekton-catalog-structure]: https://github.com/tektoncd/catalog?tab=readme-ov-file#catalog-structure
+[Renovate]: https://docs.renovatebot.com/
+[renovate-ignorepaths]: https://docs.renovatebot.com/configuration-options/#ignorepaths
 
 ### Task Integration Tests
 

--- a/hack/renovate-ignore-shared-ci.sh
+++ b/hack/renovate-ignore-shared-ci.sh
@@ -6,16 +6,45 @@ set -o errexit -o nounset -o pipefail
 # Please consider sending a PR upstream instead of editing the file directly.
 # See the SHARED-CI.md document in this repo for more details.
 
+# Finds the Renovate configuration file (typically renovate.json) in the repo and updates
+# ignorePaths to include all the .github/ files that come from the Shared CI repository.
+#
+# If there is no Renovate configuration file, creates a new renovate.json.
+
+# https://docs.renovatebot.com/configuration-options/
+# We don't support json5, but let's ignore the file extension
+#   .json doesn't mean it's not JSON5, and .json5 doesn't mean it's not regular JSON
+#   Leave it to jq to fail if failure is unavoidable
+renovate_config_paths=(
+    renovate.json
+    renovate.json5
+    .github/renovate.json
+    .github/renovate.json5
+    .gitlab/renovate.json
+    .gitlab/renovate.json5
+    .renovaterc
+    .renovaterc.json
+    .renovaterc.json5
+)
+
+renovate_config_path=${renovate_config_paths[0]}
+for filepath in "${renovate_config_paths[@]}"; do
+    if [[ -e "$filepath" ]]; then
+        renovate_config_path=$filepath
+        break
+    fi
+done
+
 shared_ci_files=$(
     grep -R '^# <TEMPLATED FILE!>' .github/ --files-with-matches |
     jq --raw-input | jq --slurp --compact-output
 )
 
 new_renovate_json=$(
-    if [[ -s renovate.json ]]; then
-        cat renovate.json
+    if [[ -s "$renovate_config_path" ]]; then
+        cat "$renovate_config_path"
     else
-        # renovate.json empty or missing => use default config
+        # $renovate_config_path empty or missing => use default config
         # https://docs.renovatebot.com/config-overview/#onboarding-config
         jq -n '{
             "$schema": "https://docs.renovatebot.com/renovate-schema.json"
@@ -31,12 +60,12 @@ new_renovate_json=$(
 )
 
 if [[ -z "$new_renovate_json" ]]; then
-    echo "renovate.json is up to date" >&2
+    echo "$renovate_config_path is up to date" >&2
 else
-    if [[ -e renovate.json ]]; then
-        echo "updated renovate.json" >&2
+    if [[ -e "$renovate_config_path" ]]; then
+        echo "updated $renovate_config_path" >&2
     else
-        echo "created renovate.json" >&2
+        echo "created $renovate_config_path" >&2
     fi
-    printf '%s\n' "$new_renovate_json" > renovate.json
+    printf '%s\n' "$new_renovate_json" > "$renovate_config_path"
 fi

--- a/hack/renovate-ignore-shared-ci.sh
+++ b/hack/renovate-ignore-shared-ci.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+# <TEMPLATED FILE!>
+# This file comes from the templates at https://github.com/konflux-ci/task-repo-shared-ci.
+# Please consider sending a PR upstream instead of editing the file directly.
+# See the SHARED-CI.md document in this repo for more details.
+
+shared_ci_files=$(
+    grep -R '^# <TEMPLATED FILE!>' .github/ --files-with-matches |
+    jq --raw-input | jq --slurp --compact-output
+)
+
+new_renovate_json=$(
+    if [[ -s renovate.json ]]; then
+        cat renovate.json
+    else
+        # renovate.json empty or missing => use default config
+        # https://docs.renovatebot.com/config-overview/#onboarding-config
+        jq -n '{
+            "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+        }'
+    fi | jq --argjson shared_ci_files "$shared_ci_files" '
+        ((.ignorePaths + $shared_ci_files) | unique) as $new_ignore_paths |
+        if .ignorePaths == $new_ignore_paths then
+            empty
+        else
+            .ignorePaths = $new_ignore_paths
+        end
+    '
+)
+
+if [[ -z "$new_renovate_json" ]]; then
+    echo "renovate.json is up to date" >&2
+else
+    if [[ -e renovate.json ]]; then
+        echo "updated renovate.json" >&2
+    else
+        echo "created renovate.json" >&2
+    fi
+    printf '%s\n' "$new_renovate_json" > renovate.json
+fi

--- a/{{cookiecutter.repo_root}}/.github/workflows/update-shared-ci.yaml
+++ b/{{cookiecutter.repo_root}}/.github/workflows/update-shared-ci.yaml
@@ -58,8 +58,30 @@ jobs:
             echo draft=false >> "$GITHUB_OUTPUT"
           fi
 
-          if [[ ! -e renovate.json ]]; then
-            echo "renovate.json doesn't exist, skipping update" >&2
+          renovate_config_exists() {
+            # https://docs.renovatebot.com/configuration-options/
+            local renovate_config_paths=(
+              renovate.json
+              renovate.json5
+              .github/renovate.json
+              .github/renovate.json5
+              .gitlab/renovate.json
+              .gitlab/renovate.json5
+              .renovaterc
+              .renovaterc.json
+              .renovaterc.json5
+            )
+
+            for file in "${renovate_config_paths[@]}"; do
+              if [[ -e "$file" ]]; then
+                return 0
+              fi
+            done
+
+            return 1
+          }
+          if ! renovate_config_exists; then
+            echo "Renovate config file not found, skipping update" >&2
             exit
           fi
 

--- a/{{cookiecutter.repo_root}}/.github/workflows/update-shared-ci.yaml
+++ b/{{cookiecutter.repo_root}}/.github/workflows/update-shared-ci.yaml
@@ -58,6 +58,29 @@ jobs:
             echo draft=false >> "$GITHUB_OUTPUT"
           fi
 
+          if [[ ! -e renovate.json ]]; then
+            echo "renovate.json doesn't exist, skipping update" >&2
+            exit
+          fi
+
+          renovate_update_script=hack/renovate-ignore-shared-ci.sh
+
+          for conflict in "${merge_conflicts[@]}" "${rejected_patches[@]}"; do
+            if [[ "$conflict" == "$renovate_update_script" ]]; then
+              cat << EOF >> /tmp/body.md
+
+          > [!WARNING]
+          >
+          > \`$renovate_update_script\` has a merge conflict, the workflow couldn't run it.
+          > After resolving the conflict, please run the script manually.
+          EOF
+              echo "cannot run $renovate_update_script due to merge conflict, skipping" >&2
+              exit
+            fi
+          done
+
+          bash "$renovate_update_script"
+
       - uses: actions/create-github-app-token@v2.0.6
         id: app-token
         with:

--- a/{{cookiecutter.repo_root}}/SHARED-CI.md
+++ b/{{cookiecutter.repo_root}}/SHARED-CI.md
@@ -188,17 +188,6 @@ run the script to automatically update `renovate.json`.
 This ensures your Shared CI workflows follow the GitHub Actions versions defined
 in the upstream reposistory and avoids unnecessary merge conflicts.
 
-[task-repo-shared-ci]: https://github.com/konflux-ci/task-repo-shared-ci
-[onboarding process]: https://github.com/konflux-ci/task-repo-shared-ci?tab=readme-ov-file#-onboarding
-[cruft]: https://cruft.github.io/cruft
-[uv]: https://docs.astral.sh/uv/
-[recipe.yaml]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts#configuration-in-recipeyaml
-[trusted-artifacts generator]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts
-[GITHUB_TOKEN]: https://docs.github.com/en/actions/concepts/security/github_token
-[tekton-catalog-structure]: https://github.com/tektoncd/catalog?tab=readme-ov-file#catalog-structure
-[Renovate]: https://docs.renovatebot.com/
-[renovate-ignorepaths]: https://docs.renovatebot.com/configuration-options/#ignorepaths
-
 ### Task Integration Tests
 
 - workflow: [`.github/workflows/run-task-tests.yaml`](.github/workflows/run-task-tests.yaml)
@@ -288,3 +277,15 @@ This check **disallows using `$(params.*)` variable substitution directly within
 Using `$(params.*)` directly in a script creates a security flaw. Tekton performs a raw text replacement of the parameter placeholder before the script is executed. This means if a parameter's value contains malicious shell commands, they will be run, leading to **arbitrary code execution**.
 
 For more details and guidance on fixing the issue, see the [Tekton recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md#dont-use-interpolation-in-scripts-or-string-arguments)
+
+
+[task-repo-shared-ci]: https://github.com/konflux-ci/task-repo-shared-ci
+[onboarding process]: https://github.com/konflux-ci/task-repo-shared-ci?tab=readme-ov-file#-onboarding
+[cruft]: https://cruft.github.io/cruft
+[uv]: https://docs.astral.sh/uv/
+[recipe.yaml]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts#configuration-in-recipeyaml
+[trusted-artifacts generator]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts
+[GITHUB_TOKEN]: https://docs.github.com/en/actions/concepts/security/github_token
+[tekton-catalog-structure]: https://github.com/tektoncd/catalog?tab=readme-ov-file#catalog-structure
+[Renovate]: https://docs.renovatebot.com/
+[renovate-ignorepaths]: https://docs.renovatebot.com/configuration-options/#ignorepaths

--- a/{{cookiecutter.repo_root}}/SHARED-CI.md
+++ b/{{cookiecutter.repo_root}}/SHARED-CI.md
@@ -122,6 +122,10 @@ You can also trigger it manually from the Actions tab of your repo.
 > can encounter merge conflicts. When that happens, the workflow will send the
 > PR anyway but with the merge conflicts included. The PR will be in draft state
 > and will include a caution note (like this one, but red) with instructions.
+>
+> If your repository uses Renovate for automated dependency updates, that may increase
+> the chance of merge conflicts. See [Conflicts with Renovate](#conflicts-with-renovate)
+> for the solution.
 
 #### Required secrets
 
@@ -169,13 +173,31 @@ to avoid those restrictions.
    - `SHARED_CI_UPDATER_APP_ID`: the App ID number
    - `SHARED_CI_UPDATER_PRIVATE_KEY`: plaintext content of the private key
 
+#### Conflicts with Renovate
+
+If your repository uses [Renovate], you could frequently get merge conflicts
+during the Shared CI updates, because your repository gets GitHub Actions updates
+at a different rate than the upstream [task-repo-shared-ci] repository.
+
+To avoid that, your repo gets the [`hack/renovate-ignore-shared-ci.sh`](hack/renovate-ignore-shared-ci.sh)
+script. Run this script during the [onboarding process] to add all the Shared CI
+workflows to the [`ignorePaths`][renovate-ignorepaths] in your `renovate.json`.
+Afterwards, any time the updater workflow brings in a new workflow file, it will
+run the script to automatically update `renovate.json`.
+
+This ensures your Shared CI workflows follow the GitHub Actions versions defined
+in the upstream reposistory and avoids unnecessary merge conflicts.
+
 [task-repo-shared-ci]: https://github.com/konflux-ci/task-repo-shared-ci
+[onboarding process]: https://github.com/konflux-ci/task-repo-shared-ci?tab=readme-ov-file#-onboarding
 [cruft]: https://cruft.github.io/cruft
 [uv]: https://docs.astral.sh/uv/
 [recipe.yaml]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts#configuration-in-recipeyaml
 [trusted-artifacts generator]: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts
 [GITHUB_TOKEN]: https://docs.github.com/en/actions/concepts/security/github_token
 [tekton-catalog-structure]: https://github.com/tektoncd/catalog?tab=readme-ov-file#catalog-structure
+[Renovate]: https://docs.renovatebot.com/
+[renovate-ignorepaths]: https://docs.renovatebot.com/configuration-options/#ignorepaths
 
 ### Task Integration Tests
 

--- a/{{cookiecutter.repo_root}}/hack/renovate-ignore-shared-ci.sh
+++ b/{{cookiecutter.repo_root}}/hack/renovate-ignore-shared-ci.sh
@@ -6,16 +6,45 @@ set -o errexit -o nounset -o pipefail
 # Please consider sending a PR upstream instead of editing the file directly.
 # See the SHARED-CI.md document in this repo for more details.
 
+# Finds the Renovate configuration file (typically renovate.json) in the repo and updates
+# ignorePaths to include all the .github/ files that come from the Shared CI repository.
+#
+# If there is no Renovate configuration file, creates a new renovate.json.
+
+# https://docs.renovatebot.com/configuration-options/
+# We don't support json5, but let's ignore the file extension
+#   .json doesn't mean it's not JSON5, and .json5 doesn't mean it's not regular JSON
+#   Leave it to jq to fail if failure is unavoidable
+renovate_config_paths=(
+    renovate.json
+    renovate.json5
+    .github/renovate.json
+    .github/renovate.json5
+    .gitlab/renovate.json
+    .gitlab/renovate.json5
+    .renovaterc
+    .renovaterc.json
+    .renovaterc.json5
+)
+
+renovate_config_path=${renovate_config_paths[0]}
+for filepath in "${renovate_config_paths[@]}"; do
+    if [[ -e "$filepath" ]]; then
+        renovate_config_path=$filepath
+        break
+    fi
+done
+
 shared_ci_files=$(
     grep -R '^# <TEMPLATED FILE!>' .github/ --files-with-matches |
     jq --raw-input | jq --slurp --compact-output
 )
 
 new_renovate_json=$(
-    if [[ -s renovate.json ]]; then
-        cat renovate.json
+    if [[ -s "$renovate_config_path" ]]; then
+        cat "$renovate_config_path"
     else
-        # renovate.json empty or missing => use default config
+        # $renovate_config_path empty or missing => use default config
         # https://docs.renovatebot.com/config-overview/#onboarding-config
         jq -n '{
             "$schema": "https://docs.renovatebot.com/renovate-schema.json"
@@ -31,12 +60,12 @@ new_renovate_json=$(
 )
 
 if [[ -z "$new_renovate_json" ]]; then
-    echo "renovate.json is up to date" >&2
+    echo "$renovate_config_path is up to date" >&2
 else
-    if [[ -e renovate.json ]]; then
-        echo "updated renovate.json" >&2
+    if [[ -e "$renovate_config_path" ]]; then
+        echo "updated $renovate_config_path" >&2
     else
-        echo "created renovate.json" >&2
+        echo "created $renovate_config_path" >&2
     fi
-    printf '%s\n' "$new_renovate_json" > renovate.json
+    printf '%s\n' "$new_renovate_json" > "$renovate_config_path"
 fi

--- a/{{cookiecutter.repo_root}}/hack/renovate-ignore-shared-ci.sh
+++ b/{{cookiecutter.repo_root}}/hack/renovate-ignore-shared-ci.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+# <TEMPLATED FILE!>
+# This file comes from the templates at https://github.com/konflux-ci/task-repo-shared-ci.
+# Please consider sending a PR upstream instead of editing the file directly.
+# See the SHARED-CI.md document in this repo for more details.
+
+shared_ci_files=$(
+    grep -R '^# <TEMPLATED FILE!>' .github/ --files-with-matches |
+    jq --raw-input | jq --slurp --compact-output
+)
+
+new_renovate_json=$(
+    if [[ -s renovate.json ]]; then
+        cat renovate.json
+    else
+        # renovate.json empty or missing => use default config
+        # https://docs.renovatebot.com/config-overview/#onboarding-config
+        jq -n '{
+            "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+        }'
+    fi | jq --argjson shared_ci_files "$shared_ci_files" '
+        ((.ignorePaths + $shared_ci_files) | unique) as $new_ignore_paths |
+        if .ignorePaths == $new_ignore_paths then
+            empty
+        else
+            .ignorePaths = $new_ignore_paths
+        end
+    '
+)
+
+if [[ -z "$new_renovate_json" ]]; then
+    echo "renovate.json is up to date" >&2
+else
+    if [[ -e renovate.json ]]; then
+        echo "updated renovate.json" >&2
+    else
+        echo "created renovate.json" >&2
+    fi
+    printf '%s\n' "$new_renovate_json" > renovate.json
+fi


### PR DESCRIPTION
We want to enable Renovate bot in this repository.

However, this creates a problem. If the shared-ci users (those who
include the templates from this repo in their own repo) have Renovate
enabled as well, they will often get merge conflicts from 'cruft update'
due to having different GH actions versions compared to this repo.

To solve the problem, write a script that finds all the shared-ci
workflows in the repo and updates renovate.json to ignore them all.

The script will *not* be used in this repo itself. The state that we
want to achieve is:

* this repo gets Renovate updates for the shared CI workflows
* shared-ci users do not get Renovate updates for the same workflows
* they get the updates from from the 'cruft update' workflow, which
  updates their files to match the ones in this repo

How shared-ci users will use this script:
* When onboarding a repo to shared-ci, the user should run the script to
  create/update their renovate.json
* The update-shared-ci workflow will run the script automatically