### PR TITLE
Add task-lint workflow

### DIFF
--- a/.github/workflows/task-lint.yaml
+++ b/.github/workflows/task-lint.yaml
@@ -1,0 +1,44 @@
+# <TEMPLATED FILE!>
+# This file comes from the templates at https://github.com/konflux-ci/task-repo-shared-ci.
+# Please consider sending a PR upstream instead of editing the file directly.
+# See the SHARED-CI.md document in this repo for more details.
+
+name: "Lint Tekton Tasks"
+
+'on':
+  pull_request:
+    branches: [main]
+    paths:
+      - 'task/**/*.yaml'
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  lint-disallowed-params:
+    name: "Check for insecure params in tasks"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout this repository"
+        uses: actions/checkout@v4
+
+      - name: "Install yq"
+        uses: mikefarah/yq@v4
+        with:
+          # Version from https://github.com/mikefarah/yq/releases
+          version: 'v4.47.1'
+
+      - name: "Run linter script"
+        id: linter-script
+        run: |
+          #!/bin/bash
+          for task in $(find task -name '*.yaml'); do
+            if yq '.spec?.steps[] | .script' $task | grep -q '\$(params\.'; then
+              FAILED_TASKS="$FAILED_TASKS $task"
+            fi
+          done
+          if [ -n "$FAILED_TASKS" ]; then
+            echo "Tasks contains params in script section (https://github.com/tektoncd/catalog/blob/main/recommendations.md#dont-use-interpolation-in-scripts-or-string-arguments)"
+            echo "This is disallowed as it can lead to arbitrary code execution"
+            echo $FAILED_TASKS | tr ' ' '\n' | sort
+            exit 1
+          fi

--- a/SHARED-CI.md
+++ b/SHARED-CI.md
@@ -238,3 +238,15 @@ echo "Pre-requirements setup complete for namespace: $TEST_NS"
 
 ```
 </details>  
+
+### Tekton Security Task Lint
+
+To enforce secure CI practices, we lint all Tekton Tasks on every pull request using the `task-lint.yaml` workflow.
+
+#### Purpose
+
+This check **disallows using `$(params.*)` variable substitution directly within a `script` block** of a Tekton Task.
+
+Using `$(params.*)` directly in a script creates a security flaw. Tekton performs a raw text replacement of the parameter placeholder before the script is executed. This means if a parameter's value contains malicious shell commands, they will be run, leading to **arbitrary code execution**.
+
+For more details and guidance on fixing the issue, see the [Tekton recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md#dont-use-interpolation-in-scripts-or-string-arguments)

--- a/{{cookiecutter.repo_root}}/.github/workflows/task-lint.yaml
+++ b/{{cookiecutter.repo_root}}/.github/workflows/task-lint.yaml
@@ -1,0 +1,44 @@
+# <TEMPLATED FILE!>
+# This file comes from the templates at https://github.com/konflux-ci/task-repo-shared-ci.
+# Please consider sending a PR upstream instead of editing the file directly.
+# See the SHARED-CI.md document in this repo for more details.
+
+name: "Lint Tekton Tasks"
+
+'on':
+  pull_request:
+    branches: [main]
+    paths:
+      - 'task/**/*.yaml'
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  lint-disallowed-params:
+    name: "Check for insecure params in tasks"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout this repository"
+        uses: actions/checkout@v4
+
+      - name: "Install yq"
+        uses: mikefarah/yq@v4
+        with:
+          # Version from https://github.com/mikefarah/yq/releases
+          version: 'v4.47.1'
+
+      - name: "Run linter script"
+        id: linter-script
+        run: |
+          #!/bin/bash
+          for task in $(find task -name '*.yaml'); do
+            if yq '.spec?.steps[] | .script' $task | grep -q '\$(params\.'; then
+              FAILED_TASKS="$FAILED_TASKS $task"
+            fi
+          done
+          if [ -n "$FAILED_TASKS" ]; then
+            echo "Tasks contains params in script section (https://github.com/tektoncd/catalog/blob/main/recommendations.md#dont-use-interpolation-in-scripts-or-string-arguments)"
+            echo "This is disallowed as it can lead to arbitrary code execution"
+            echo $FAILED_TASKS | tr ' ' '\n' | sort
+            exit 1
+          fi

--- a/{{cookiecutter.repo_root}}/SHARED-CI.md
+++ b/{{cookiecutter.repo_root}}/SHARED-CI.md
@@ -238,3 +238,15 @@ echo "Pre-requirements setup complete for namespace: $TEST_NS"
 
 ```
 </details>  
+
+### Tekton Security Task Lint
+
+To enforce secure CI practices, we lint all Tekton Tasks on every pull request using the `task-lint.yaml` workflow.
+
+#### Purpose
+
+This check **disallows using `$(params.*)` variable substitution directly within a `script` block** of a Tekton Task.
+
+Using `$(params.*)` directly in a script creates a security flaw. Tekton performs a raw text replacement of the parameter placeholder before the script is executed. This means if a parameter's value contains malicious shell commands, they will be run, leading to **arbitrary code execution**.
+
+For more details and guidance on fixing the issue, see the [Tekton recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md#dont-use-interpolation-in-scripts-or-string-arguments)


### PR DESCRIPTION
I've added the [task-lint](https://github.com/konflux-ci/build-definitions/blob/6fd7e5897bd682d372b8adff39f439fa54a582ca/.tekton/tasks/task-lint.yaml) from build-definitions and added it as a GH workflow.

For more details, see commit messages.

### Test
I've added temp test commit, to intentionally fail the workflow. 