### PR TITLE
renovate: update konflux-ci commit only on sunday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,14 @@
         "pin"
       ],
       "automerge": true
+    },
+    {
+      "matchDepNames": [
+        "konflux-ci"
+      ],
+      "schedule": [
+        "on sunday"
+      ]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Similar to github actions updates, reduce the amount of noise by updating only once a week.