### PR TITLE
Fix Checkton warnings

### DIFF
--- a/.github/workflows/task-lint.yaml
+++ b/.github/workflows/task-lint.yaml
@@ -31,14 +31,19 @@ jobs:
         id: linter-script
         run: |
           #!/bin/bash
-          for task in $(find task -name '*.yaml'); do
-            if yq '.spec?.steps[] | .script' $task | grep -q '\$(params\.'; then
-              FAILED_TASKS="$FAILED_TASKS $task"
+
+          FAILED_TASKS=()
+
+          while read -r task; do
+            # shellcheck disable=SC2016  # we don't want to expand $(params)
+            if yq '.spec?.steps[] | .script' "$task" | grep -q '\$(params\.'; then
+              FAILED_TASKS+=("$task")
             fi
-          done
-          if [ -n "$FAILED_TASKS" ]; then
+          done < <(find task -name '*.yaml')
+
+          if [ "${#FAILED_TASKS[@]}" -gt 0 ]; then
             echo "Tasks contains params in script section (https://github.com/tektoncd/catalog/blob/main/recommendations.md#dont-use-interpolation-in-scripts-or-string-arguments)"
             echo "This is disallowed as it can lead to arbitrary code execution"
-            echo $FAILED_TASKS | tr ' ' '\n' | sort
+            printf '%s\n' "${FAILED_TASKS[@]}" | sort
             exit 1
           fi

--- a/.github/workflows/update-shared-ci.yaml
+++ b/.github/workflows/update-shared-ci.yaml
@@ -52,8 +52,9 @@ jobs:
           >
           > Please address the problems manually and then mark the PR ready for review.
           >
-          $(printf '> - ❌ `%s`\n' "${merge_conflicts[@]}" "${rejected_patches[@]}")
           EOF
+            # shellcheck disable=SC2016  # we don't want to expand the backticks
+            printf '> - ❌ `%s`\n' "${merge_conflicts[@]}" "${rejected_patches[@]}" >> /tmp/body.md
           else
             echo draft=false >> "$GITHUB_OUTPUT"
           fi

--- a/{{cookiecutter.repo_root}}/.github/workflows/task-lint.yaml
+++ b/{{cookiecutter.repo_root}}/.github/workflows/task-lint.yaml
@@ -31,14 +31,19 @@ jobs:
         id: linter-script
         run: |
           #!/bin/bash
-          for task in $(find task -name '*.yaml'); do
-            if yq '.spec?.steps[] | .script' $task | grep -q '\$(params\.'; then
-              FAILED_TASKS="$FAILED_TASKS $task"
+
+          FAILED_TASKS=()
+
+          while read -r task; do
+            # shellcheck disable=SC2016  # we don't want to expand $(params)
+            if yq '.spec?.steps[] | .script' "$task" | grep -q '\$(params\.'; then
+              FAILED_TASKS+=("$task")
             fi
-          done
-          if [ -n "$FAILED_TASKS" ]; then
+          done < <(find task -name '*.yaml')
+
+          if [ "${#FAILED_TASKS[@]}" -gt 0 ]; then
             echo "Tasks contains params in script section (https://github.com/tektoncd/catalog/blob/main/recommendations.md#dont-use-interpolation-in-scripts-or-string-arguments)"
             echo "This is disallowed as it can lead to arbitrary code execution"
-            echo $FAILED_TASKS | tr ' ' '\n' | sort
+            printf '%s\n' "${FAILED_TASKS[@]}" | sort
             exit 1
           fi

--- a/{{cookiecutter.repo_root}}/.github/workflows/update-shared-ci.yaml
+++ b/{{cookiecutter.repo_root}}/.github/workflows/update-shared-ci.yaml
@@ -52,8 +52,9 @@ jobs:
           >
           > Please address the problems manually and then mark the PR ready for review.
           >
-          $(printf '> - ❌ `%s`\n' "${merge_conflicts[@]}" "${rejected_patches[@]}")
           EOF
+            # shellcheck disable=SC2016  # we don't want to expand the backticks
+            printf '> - ❌ `%s`\n' "${merge_conflicts[@]}" "${rejected_patches[@]}" >> /tmp/body.md
           else
             echo draft=false >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
Fix the existing warnings reported by Checkton so that users don't see a failing Checkton workflow when they onboard.

Verified with:

```bash
CHECKTON_DIFFERENTIAL=false CHECKTON_INCLUDE_REGEX='^\.github/.*\.yaml$' hack/checkton-local.sh
```