### PR TITLE
generate-ta: don't mention generate-everything.sh

### DIFF
--- a/hack/generate-ta-tasks.sh
+++ b/hack/generate-ta-tasks.sh
@@ -56,7 +56,6 @@ msg="File is out of date and has been updated"
 if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
   # shellcheck disable=SC2016
   msg='File is out of date, run `hack/generate-ta-tasks.sh` and include the updated file with your changes.'
-  msg+=' Or run ./hack/generate-everything.sh to run all the generators at once.'
 fi
 
 cd "${TASK_DIR}"

--- a/{{cookiecutter.repo_root}}/hack/generate-ta-tasks.sh
+++ b/{{cookiecutter.repo_root}}/hack/generate-ta-tasks.sh
@@ -56,7 +56,6 @@ msg="File is out of date and has been updated"
 if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
   # shellcheck disable=SC2016
   msg='File is out of date, run `hack/generate-ta-tasks.sh` and include the updated file with your changes.'
-  msg+=' Or run ./hack/generate-everything.sh to run all the generators at once.'
 fi
 
 cd "${TASK_DIR}"


### PR DESCRIPTION
We don't provide that script, and there probably isn't a strong reason to. Unlike build-definitions, which has five different generators, three of which have to run in a specific order, shared-ci has two generators with no defined order (kustomize and the TA generator).

If shared-ci users have more specific auto-generation requirements, they should create their own generate-everything scripts.