### PR TITLE
fix: allow TEST_ITEMS env var without CLI arguments in test_tekton_ta…

### DIFF
--- a/.github/scripts/test_tekton_tasks.sh
+++ b/.github/scripts/test_tekton_tasks.sh
@@ -31,7 +31,7 @@ shopt -s nullglob
 
 WORKSPACE_TEMPLATE=${BASH_SOURCE%/*/*}/resources/workspace-template.yaml
 
-if [[ $# -eq 0 || ${1} == "-h" ]]; then
+if [[ ${1:-} == "-h" ]] || [[ $# -eq 0 && -z "${TEST_ITEMS}" ]]; then
     cat <<EOF
 Error: No task directories.
 

--- a/{{cookiecutter.repo_root}}/.github/scripts/test_tekton_tasks.sh
+++ b/{{cookiecutter.repo_root}}/.github/scripts/test_tekton_tasks.sh
@@ -31,7 +31,7 @@ shopt -s nullglob
 
 WORKSPACE_TEMPLATE=${BASH_SOURCE%/*/*}/resources/workspace-template.yaml
 
-if [[ $# -eq 0 || ${1} == "-h" ]]; then
+if [[ ${1:-} == "-h" ]] || [[ $# -eq 0 && -z "${TEST_ITEMS}" ]]; then
     cat <<EOF
 Error: No task directories.
 


### PR DESCRIPTION
…sks.sh

The script would always exit with an error when no CLI arguments were provided, even if TEST_ITEMS was set via environment variable. Fix the guard condition to only require CLI arguments when TEST_ITEMS is unset.