### PR TITLE
generate-ta-tasks: fix task paths

### DIFF
--- a/hack/generate-ta-tasks.sh
+++ b/hack/generate-ta-tasks.sh
@@ -59,7 +59,9 @@ fi
 
 cd "${TASK_DIR}"
 for recipe_path in **/recipe.yaml; do
-    task_path="${recipe_path%/recipe.yaml}/$(basename "${recipe_path%/*/*}").yaml"
+    # tasks are stored at task/${task_name}/...
+    task_name="${recipe_path%%/*}"
+    task_path="${recipe_path%/*}/${task_name}.yaml"
     sponge=$(tash "${TASK_DIR}/${recipe_path}")
     echo "${sponge}" > "${task_path}"
     if ! git diff --quiet HEAD "${task_path}"; then

--- a/task/goodbye-oci-ta/goodbye-oci-ta.yaml
+++ b/task/goodbye-oci-ta/goodbye-oci-ta.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: goodbye-oci-ta
+  annotations:
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: 0.1.0
+spec:
+  description: |-
+    Example task without version subdirectory (kustomize-generated).
+
+    This task demonstrates the flexible directory structure where tasks
+    can be placed directly under task/${task_name}/ without a version folder.
+  params:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: ""
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+  results:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:7c51a3530f239323442e28ea7dace8b88a14638d823d5eaa8514843c33b03c02
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: goodbye
+      image: registry.access.redhat.com/ubi9/ubi-micro:9.6@sha256:f5c5213d2969b7b11a6666fc4b849d56b48d9d7979b60a37bb853dff0255c14b
+      script: |
+        #!/bin/bash
+        echo "Goodbye!" >>"/var/workdir/goodbye.txt"
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+    - name: create-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:7c51a3530f239323442e28ea7dace8b88a14638d823d5eaa8514843c33b03c02
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi

--- a/task/greet-oci-ta/subdir/deep/greet-oci-ta.yaml
+++ b/task/greet-oci-ta/subdir/deep/greet-oci-ta.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: greet-oci-ta
+  annotations:
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: 1.0.0
+spec:
+  description: |-
+    Example task with deeply nested directory structure.
+
+    This task demonstrates the flexible directory structure where tasks
+    can be placed at arbitrary nesting levels under task/${task_name}/.
+  params:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: ""
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+  results:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:7c51a3530f239323442e28ea7dace8b88a14638d823d5eaa8514843c33b03c02
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: greet
+      image: registry.access.redhat.com/ubi9/ubi-micro:9.6@sha256:f5c5213d2969b7b11a6666fc4b849d56b48d9d7979b60a37bb853dff0255c14b
+      script: |
+        #!/bin/bash
+        echo "Greetings from a deeply nested task!" >>"/var/workdir/greet.txt"
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+    - name: create-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:7c51a3530f239323442e28ea7dace8b88a14638d823d5eaa8514843c33b03c02
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi

--- a/{{cookiecutter.repo_root}}/hack/generate-ta-tasks.sh
+++ b/{{cookiecutter.repo_root}}/hack/generate-ta-tasks.sh
@@ -59,7 +59,9 @@ fi
 
 cd "${TASK_DIR}"
 for recipe_path in **/recipe.yaml; do
-    task_path="${recipe_path%/recipe.yaml}/$(basename "${recipe_path%/*/*}").yaml"
+    # tasks are stored at task/${task_name}/...
+    task_name="${recipe_path%%/*}"
+    task_path="${recipe_path%/*}/${task_name}.yaml"
     sponge=$(tash "${TASK_DIR}/${recipe_path}")
     echo "${sponge}" > "${task_path}"
     if ! git diff --quiet HEAD "${task_path}"; then


### PR DESCRIPTION
Previously, if the recipe.yaml files weren't nested exactly 2 level under task/, the output filenames would be nonsensical. For our own examples, the script would generate files like:

    task/goodbye-oci-ta/recipe.yaml.yaml
    task/greet-oci-ta/subdir/deep/subdir.yaml

Fix the paths and commit the generated files that now have the expected filenames:

    task/goodbye-oci-ta/goodbye-oci-ta.yaml
    task/greet-oci-ta/subdir/deep/greet-oci-ta.yaml