### PR TITLE
fix(generate-ta-tasks): pass task path to generator for digest reuse

### DIFF
--- a/hack/generate-ta-tasks.sh
+++ b/hack/generate-ta-tasks.sh
@@ -62,7 +62,7 @@ for recipe_path in **/recipe.yaml; do
     # tasks are stored at task/${task_name}/...
     task_name="${recipe_path%%/*}"
     task_path="${recipe_path%/*}/${task_name}.yaml"
-    sponge=$(tash "${TASK_DIR}/${recipe_path}")
+    sponge=$(tash "${TASK_DIR}/${recipe_path}" "${TASK_DIR}/${task_path}")
     echo "${sponge}" > "${task_path}"
     if ! git diff --quiet HEAD "${task_path}"; then
         emit "task/${task_path}" "${msg}"

--- a/{{cookiecutter.repo_root}}/hack/generate-ta-tasks.sh
+++ b/{{cookiecutter.repo_root}}/hack/generate-ta-tasks.sh
@@ -62,7 +62,7 @@ for recipe_path in **/recipe.yaml; do
     # tasks are stored at task/${task_name}/...
     task_name="${recipe_path%%/*}"
     task_path="${recipe_path%/*}/${task_name}.yaml"
-    sponge=$(tash "${TASK_DIR}/${recipe_path}")
+    sponge=$(tash "${TASK_DIR}/${recipe_path}" "${TASK_DIR}/${task_path}")
     echo "${sponge}" > "${task_path}"
     if ! git diff --quiet HEAD "${task_path}"; then
         emit "task/${task_path}" "${msg}"


### PR DESCRIPTION
For more information see [this PR](https://github.com/konflux-ci/build-definitions/pull/3650).

Note that this PR has to be merger AFTER the one in build-definitions