### PR TITLE
fix: remove stale rate-limit error handler from setup-tektoncd step

### DIFF
--- a/.github/workflows/check-task-migration.yaml
+++ b/.github/workflows/check-task-migration.yaml
@@ -24,18 +24,8 @@ jobs:
         with:
           cluster_name: kind
       - uses: tektoncd/actions/setup-tektoncd@main
-        id: setup-tektoncd
         with:
           pipeline_version: latest
-        continue-on-error: true
-      - name: Describe setup-tektoncd failure
-        if: steps.setup-tektoncd.outcome != 'success'
-        run: |
-          curl -s https://api.github.com/repos/tektoncd/pipeline/releases/latest | jq
-          echo "The previous action setup-tektoncd seems to have failed due to a known issue caused by hitting the rate-limit"
-          echo "For more information, follow the following issue: https://github.com/tektoncd/actions/issues/9"
-          echo "The only known workaround at the moment is to re-run this workflow."
-          exit 1
       - name: Run check
         run: |
           DEBIAN_FRONTEND=noninteractive \

--- a/{{cookiecutter.repo_root}}/.github/workflows/check-task-migration.yaml
+++ b/{{cookiecutter.repo_root}}/.github/workflows/check-task-migration.yaml
@@ -24,18 +24,8 @@ jobs:
         with:
           cluster_name: kind
       - uses: tektoncd/actions/setup-tektoncd@main
-        id: setup-tektoncd
         with:
           pipeline_version: latest
-        continue-on-error: true
-      - name: Describe setup-tektoncd failure
-        if: steps.setup-tektoncd.outcome != 'success'
-        run: |
-          curl -s https://api.github.com/repos/tektoncd/pipeline/releases/latest | jq
-          echo "The previous action setup-tektoncd seems to have failed due to a known issue caused by hitting the rate-limit"
-          echo "For more information, follow the following issue: https://github.com/tektoncd/actions/issues/9"
-          echo "The only known workaround at the moment is to re-run this workflow."
-          exit 1
       - name: Run check
         run: |
           DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
## Summary

- Remove the `continue-on-error` + "Describe setup-tektoncd failure" fallback step from the `check-task-migration` workflow (both the repo CI copy and the cookiecutter template)
- The fallback was a workaround for [tektoncd/actions#9](https://github.com/tektoncd/actions/issues/9), which has been fixed upstream by [tektoncd/actions#15](https://github.com/tektoncd/actions/pull/15) (merged 2026-07-03)

## Why

The stale fallback step is now harmful:

1. **Misleading error messages** — it always blames "rate-limit" regardless of the actual failure cause. For example, [build-definitions PR 3531](https://github.com/konflux-ci/build-definitions/pull/3531) failed with a transient HTTP 502 downloading the Tekton CLI tarball, but the error message blamed rate limiting.
2. **The upstream fix is already active** — since this workflow uses `tektoncd/actions/setup-tektoncd@main`, the fix (which switched pipeline downloads to `infra.tekton.dev` and added proper error handling) is already in effect.
3. **The unauthenticated GitHub API call in the fallback** (`curl -s https://api.github.com/repos/tektoncd/pipeline/releases/latest`) can itself trigger rate limiting, adding noise to the output.

With the fix removed, `setup-tektoncd`'s own error output surfaces directly, giving actionable information about the actual failure.

## Test plan

- [ ] CI on this PR validates the workflow syntax
- [ ] Verify that a transient `setup-tektoncd` failure surfaces the action's own error message instead of the stale rate-limit message

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)